### PR TITLE
feat: add User and Role models with migrations and seeders

### DIFF
--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -5,17 +5,16 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class User extends Model
+class Role extends Model
 {
     use HasFactory;
 
     protected $fillable = [
-        'full_name',
-        'email',
+        'name',
     ];
 
-    public function roles()
+    public function users()
     {
-        return $this->belongsToMany(Role::class);
+        return $this->belongsToMany(User::class);
     }
 }

--- a/database/migrations/2025_09_07_181857_create_roles_table.php
+++ b/database/migrations/2025_09_07_181857_create_roles_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateRolesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('roles');
+    }
+}

--- a/database/migrations/2025_09_07_181925_create_users_table.php
+++ b/database/migrations/2025_09_07_181925_create_users_table.php
@@ -15,11 +15,8 @@ class CreateUsersTable extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
+            $table->string('full_name');
             $table->string('email')->unique();
-            $table->timestamp('email_verified_at')->nullable();
-            $table->string('password');
-            $table->rememberToken();
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_09_07_181952_create_role_user_table.php
+++ b/database/migrations/2025_09_07_181952_create_role_user_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateRoleUserTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('role_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('role_id')->constrained('roles')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('role_user');
+    }
+}

--- a/database/seeders/RolesTableSeeder.php
+++ b/database/seeders/RolesTableSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class RolesTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        \DB::table('roles')->insert([
+            ['name' => 'Author'],
+            ['name' => 'Editor'],
+            ['name' => 'Subscriber'],
+            ['name' => 'Administrator'],
+        ]);
+    }
+}


### PR DESCRIPTION
**Summary**

Implements the core database schema with migrations, models, and seed data to support user-role management.
This establishes the foundation for authentication and role-based access control.

**Changes Made**

Created migrations:

users

roles

role_user (pivot table for many-to-many relationship)

Implemented Eloquent models: User, Role.

Seeded default roles: Author, Editor, Subscriber, Administrator.

Linked User and Role models with belongsToMany relationship.

**Technical Notes**

Pivot table role_user uses user_id and role_id foreign keys.

Seeder ensures roles are created automatically on fresh migrations.

Database migrations follow Laravel 8 conventions.

**Testing Steps**

Run php artisan migrate:fresh --seed.

Check that users, roles, and role_user tables are created.

Verify that default roles exist in the roles table.

Create a test user and attach a role to confirm relationship mapping.

**Checklist**

 All migrations run successfully

 Models and relationships work as expected

 Default roles seeded correctly

 Database ready for API integration